### PR TITLE
Fix: Page title shows breadcrumb name instead of JSON (fixes #18)

### DIFF
--- a/display/templates/display/page.html
+++ b/display/templates/display/page.html
@@ -1,6 +1,6 @@
 {% extends "display/base.html" %}
 
-{% block title %}{{ breadcrumbs|last|default:'Home' }} - GitWiki{% endblock %}
+{% block title %}{{ breadcrumbs|last.name|default:'Home' }} - GitWiki{% endblock %}
 
 {% block content %}
 <div class="row">


### PR DESCRIPTION
### **User description**
## Summary
Fixes #18 - Page titles now display properly formatted text instead of raw JSON dictionary objects.

## Problem
The home page and other wiki pages were displaying the entire breadcrumb dictionary in the browser title bar, showing something like:
```
{'name': 'Welcome', 'url': '/'} - GitWiki
```

This resulted in:
- Poor user experience (ugly browser tabs)
- Unprofessional appearance
- Metadata leak in search engine results
- Malformed bookmarks

## Solution
Changed the Django template to extract the `name` property from the breadcrumb dictionary:
- **Before**: `{{ breadcrumbs|last|default:'Home' }}`
- **After**: `{{ breadcrumbs|last.name|default:'Home' }}`

## Files Changed
- `display/templates/display/page.html` (1 line)

## Impact
- Low risk: Template-only change affecting HTML title tag
- High impact: Immediately improves user experience and SEO
- No database migrations or backend changes required

## Testing
Manual testing recommended:
1. Visit any wiki page
2. Check browser tab title
3. Verify it shows the page name (e.g., "Welcome - GitWiki") instead of JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Extract breadcrumb name property instead of rendering dict object

- Fixes page title displaying raw JSON in browser tabs

- Improves user experience and search engine optimization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Page Template"] -- "Extract name property" --> B["Breadcrumb Name"]
  B -- "Display in title" --> C["Browser Tab Title"]
  D["Before: Dict Object"] -.-> E["Poor UX & SEO"]
  F["After: Clean Name"] -.-> G["Professional Appearance"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.html</strong><dd><code>Extract breadcrumb name in page title template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

display/templates/display/page.html

<ul><li>Modified Django template title block to extract <code>name</code> property from <br>breadcrumb dictionary<br> <li> Changed filter from <code>{{ breadcrumbs|last }}</code> to <code>{{ breadcrumbs|last.name </code><br><code>}}</code><br> <li> Prevents raw JSON dictionary objects from appearing in browser tab <br>titles</ul>


</details>


  </td>
  <td><a href="https://github.com/jmaddington/GitWiki/pull/51/files#diff-60806bb06025f960ffc5eac9625472c5fb7af4a2e29f036fe7b715e00783bcd1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

