### PR TITLE
Security: Require authentication for all destructive operations (#60)

### DIFF
--- a/display/templates/display/attachment.html
+++ b/display/templates/display/attachment.html
@@ -134,7 +134,6 @@
                         'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
                     },
                     body: JSON.stringify({
-                        user_id: 1,  // Default user
                         file_path: '{{ file_path }}',
                         commit_message: 'Delete {{ file_name }}'
                     })

--- a/editor/serializers.py
+++ b/editor/serializers.py
@@ -10,7 +10,6 @@ from django.contrib.auth.models import User
 
 class StartEditSerializer(serializers.Serializer):
     """Serializer for starting an edit session."""
-    user_id = serializers.IntegerField(required=True, min_value=1)
     file_path = serializers.CharField(required=True, max_length=1024)
 
     def validate_file_path(self, value):
@@ -111,7 +110,6 @@ class UploadFileSerializer(serializers.Serializer):
 
 class QuickUploadFileSerializer(serializers.Serializer):
     """Serializer for quick file upload without edit session."""
-    user_id = serializers.IntegerField(required=True, min_value=1)
     file = serializers.FileField(required=True)
     target_path = serializers.CharField(required=False, allow_blank=True, max_length=512, default="files")
     description = serializers.CharField(required=False, allow_blank=True, max_length=200, default="")
@@ -140,7 +138,6 @@ class QuickUploadFileSerializer(serializers.Serializer):
 
 class DeleteFileSerializer(serializers.Serializer):
     """Serializer for file deletion."""
-    user_id = serializers.IntegerField(required=True, min_value=1)
     file_path = serializers.CharField(required=True, max_length=1024)
     commit_message = serializers.CharField(required=False, allow_blank=True, max_length=500)
 

--- a/editor/templates/editor/edit.html
+++ b/editor/templates/editor/edit.html
@@ -236,7 +236,6 @@
         sessionId: null,
         branchName: null,
         filePath: '{{ file_path }}',
-        userId: {{ user.id|default:"1" }},
         lastSaved: null,
         modified: false,
         autoSaveTimer: null,
@@ -382,7 +381,6 @@
 
         try {
             const response = await axios.post(`${API_BASE}/start/`, {
-                user_id: editorState.userId,
                 file_path: editorState.filePath
             });
 
@@ -686,7 +684,6 @@
         const targetPath = lastSlashIndex > 0 ? filePath.substring(0, lastSlashIndex) : '';
 
         const formData = new FormData();
-        formData.append('user_id', editorState.userId);
         formData.append('file', file);
         formData.append('target_path', targetPath);
         formData.append('description', description || '');


### PR DESCRIPTION
### **User description**
## Summary

This PR enforces authentication for all critical API endpoints to prevent unauthorized file deletion, uploads, and edits. Fixes #60.

## Problem

Previously, any visitor could perform destructive operations without authentication:
- Delete files via `/editor/api/delete-file/`
- Upload files to main branch via `/editor/api/quick-upload-file/`
- Start edit sessions via `/editor/api/start/`
- Hardcoded `user_id: 1` in templates allowed operations as default user

**Security Risk**: HIGH - Any unauthenticated visitor could delete wiki pages, upload malicious files, or modify content.

## Solution

### Phase 1: Critical Endpoints (DeleteFile & QuickUpload)
- Changed permission class from `IsAuthenticatedOrReadOnly` to `IsAuthenticated`
- Removed `user_id` fields from serializers
- Updated views to use `request.user` instead of request data
- Removed hardcoded `user_id: 1` from `display/templates/display/attachment.html`

### Phase 2: StartEdit Endpoint
- Changed permission class to `IsAuthenticated`
- Removed `user_id` from serializer and template
- Updated view to use `request.user.id` for branch creation

### Phase 3: Comprehensive Testing
- Added `EditorAuthenticationTest` class with 6 tests
- Tests verify unauthenticated users are blocked (3 tests)
- Tests verify authenticated users can proceed (3 tests)
- All tests passing ✅

## Files Changed

- `editor/api.py` - Updated 3 API views, added `IsAuthenticated` permission
- `editor/serializers.py` - Removed `user_id` from 3 serializers  
- `display/templates/display/attachment.html` - Removed hardcoded `user_id`
- `editor/templates/editor/edit.html` - Removed `userId` from state and API calls
- `editor/tests.py` - Added 110+ lines of authentication tests

## Security Impact

**Before**: HIGH RISK
- ❌ Unauthenticated users could delete files
- ❌ Unauthenticated users could upload to main branch
- ❌ No proper user attribution in commits
- ❌ Hardcoded default user in templates

**After**: LOW RISK  
- ✅ Only authenticated users can delete files
- ✅ Only authenticated users can upload files
- ✅ Proper user attribution in git commits
- ✅ API endpoints secured with `IsAuthenticated`

## Testing

All authentication tests passing:
```
Ran 6 tests in 0.805s

OK
```

Test coverage:
- ✅ Unauthenticated delete file → 302/403
- ✅ Unauthenticated quick upload → 302/403
- ✅ Unauthenticated start edit → 302/403
- ✅ Authenticated delete file → Success
- ✅ Authenticated quick upload → Not blocked by auth
- ✅ Authenticated start edit → Not blocked by auth

## Additional Changes

Closed #61 (rate limiting) as requested - not a priority at this time. Authentication requirements provide sufficient protection.

## Checklist

- [x] All destructive endpoints require authentication
- [x] Removed hardcoded user IDs from templates
- [x] All API views use `request.user`
- [x] Comprehensive tests added
- [x] All tests passing
- [x] Security vulnerability fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Enforce authentication for all destructive API endpoints
  - Changed `DeleteFileAPIView`, `QuickUploadFileAPIView`, and `StartEditAPIView` permission class from `IsAuthenticatedOrReadOnly` to `IsAuthenticated`

- Remove hardcoded user IDs from serializers and templates
  - Removed `user_id` field from `StartEditSerializer`, `QuickUploadFileSerializer`, and `DeleteFileSerializer`
  - Removed hardcoded `user_id: 1` from `display/templates/display/attachment.html` and `editor/templates/editor/edit.html`

- Use authenticated request user instead of manual user lookup
  - Updated all three API views to use `request.user` directly
  - Eliminated manual `User.objects.get_or_create()` calls

- Add comprehensive authentication test suite
  - Added `EditorAuthenticationTest` class with 6 tests covering authenticated and unauthenticated access patterns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["API Endpoints<br/>DeleteFile, QuickUpload, StartEdit"] -->|"Before: IsAuthenticatedOrReadOnly"| B["Unauthenticated Access<br/>Allowed"]
  A -->|"After: IsAuthenticated"| C["Authenticated Access<br/>Required"]
  D["Serializers<br/>user_id field"] -->|"Before: Required"| E["Manual User Lookup"]
  D -->|"After: Removed"| F["Use request.user"]
  G["Templates<br/>hardcoded user_id"] -->|"Before: user_id: 1"| H["Default User Access"]
  G -->|"After: Removed"| I["Authenticated User Only"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security, bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.py</strong><dd><code>Enforce authentication and use request.user</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

editor/api.py

<ul><li>Changed permission class from <code>IsAuthenticatedOrReadOnly</code> to <br><code>IsAuthenticated</code> for <code>DeleteFileAPIView</code>, <code>QuickUploadFileAPIView</code>, and <br><code>StartEditAPIView</code><br> <li> Removed <code>user_id</code> parameter extraction from request data in all three <br>views<br> <li> Updated views to use <code>request.user</code> directly instead of manual <br><code>User.objects.get_or_create()</code> calls<br> <li> Removed <code>User.DoesNotExist</code> exception handler from <code>DeleteFileAPIView</code> <br>since authenticated user is guaranteed<br> <li> Updated logging to use <code>user.id</code> instead of <code>user_id</code> variable</ul>


</details>


  </td>
  <td><a href="https://github.com/jmaddington/GitWiki/pull/63/files#diff-33cb35ea432c8ef4a30f8af4b2fc7b641759b23c64287f7a2fffa0eaac49a9be">+14/-34</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>serializers.py</strong><dd><code>Remove user_id fields from serializers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

editor/serializers.py

<ul><li>Removed <code>user_id</code> field from <code>StartEditSerializer</code><br> <li> Removed <code>user_id</code> field from <code>QuickUploadFileSerializer</code><br> <li> Removed <code>user_id</code> field from <code>DeleteFileSerializer</code><br> <li> All three serializers now only validate file paths and optional <br>parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/jmaddington/GitWiki/pull/63/files#diff-ff6a898d08aae5f7e1c673acb6e40892cc80aa37ee9e98ab0c92d0a626c7ba50">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>attachment.html</strong><dd><code>Remove hardcoded user_id from delete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

display/templates/display/attachment.html

<ul><li>Removed hardcoded <code>user_id: 1</code> from the delete file API request body<br> <li> API now relies on authenticated user from request context</ul>


</details>


  </td>
  <td><a href="https://github.com/jmaddington/GitWiki/pull/63/files#diff-dba5a48218f380c83ab26becea6263da4773f69cdf412e21f51ee837f0ade36f">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>edit.html</strong><dd><code>Remove userId from editor state and API calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

editor/templates/editor/edit.html

<ul><li>Removed <code>userId</code> field from <code>editorState</code> object initialization<br> <li> Removed <code>user_id</code> parameter from <code>startEditSession()</code> API call<br> <li> Removed <code>user_id</code> parameter from file upload FormData in upload handler<br> <li> API endpoints now use authenticated user from request context</ul>


</details>


  </td>
  <td><a href="https://github.com/jmaddington/GitWiki/pull/63/files#diff-3fc1023058a907c80fd9aed49298b0f1167cdf6bbd8d885b4fb98f54f02e1c5f">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tests.py</strong><dd><code>Add authentication tests for destructive operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

editor/tests.py

<ul><li>Added new <code>EditorAuthenticationTest</code> test class with 6 comprehensive <br>tests<br> <li> Tests verify unauthenticated users receive 302 or 403 responses for <br><code>start_edit</code>, <code>delete_file</code>, and <code>quick_upload</code> endpoints<br> <li> Tests verify authenticated users are not blocked by authentication <br>checks for the same endpoints<br> <li> Tests use temporary repository setup and proper cleanup with <code>setUp()</code> <br>and <code>tearDown()</code> methods</ul>


</details>


  </td>
  <td><a href="https://github.com/jmaddington/GitWiki/pull/63/files#diff-cb65becdf72b44d1e25e8842eb6a621df76fc431f512186f551de86e063a0fc5">+117/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

