### PR TITLE
Security: Require authentication for all destructive operations (#60)

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -171,7 +171,11 @@ Git Service:
 
 Editor Service:
 - EDITSESS-INACTIVE01, EDITSESS-MULTI01, EDITSESS-CONSTRAINT-FAIL01
-- EDITOR-AUTH01, EDITOR-AUTH02, EDITOR-AUTH03 (authentication required for edit operations)
+- EDITOR-AUTH01, EDITOR-AUTH02, EDITOR-AUTH03 (authentication required for edit operations - legacy codes)
+- **Authentication enforcement** (Issue #60): All destructive endpoints now require `IsAuthenticated` permission class
+  - StartEditAPIView, CommitDraftAPIView, PublishEditAPIView, UploadImageAPIView, UploadFileAPIView, QuickUploadFileAPIView, DeleteFileAPIView, ResolveConflictAPIView, DiscardDraftAPIView
+  - See SECURITY.md "Authentication and Authorization" section for patterns and best practices
+  - User attribution standardized via helper functions: `get_user_info_from_request()` and `get_user_info_from_session()`
 - EDITOR-BRANCH-RECREATE01, EDITOR-BRANCH-RECREATE02, EDITOR-BRANCH-RECREATE03
 - EDITOR-START01, EDITOR-START02, EDITOR-START03, EDITOR-START-VAL01, EDITOR-START-RACE01, EDITOR-START-RACE02, EDITOR-START-STALE01
 - EDITOR-SAVE01, EDITOR-SAVE02, EDITOR-SAVE03, EDITOR-SAVE-VAL01, EDITOR-SAVE-NOTFOUND

--- a/display/templates/display/attachment.html
+++ b/display/templates/display/attachment.html
@@ -134,7 +134,6 @@
                         'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
                     },
                     body: JSON.stringify({
-                        user_id: 1,  // Default user
                         file_path: '{{ file_path }}',
                         commit_message: 'Delete {{ file_name }}'
                     })

--- a/editor/serializers.py
+++ b/editor/serializers.py
@@ -10,7 +10,6 @@ from django.contrib.auth.models import User
 
 class StartEditSerializer(serializers.Serializer):
     """Serializer for starting an edit session."""
-    user_id = serializers.IntegerField(required=True, min_value=1)
     file_path = serializers.CharField(required=True, max_length=1024)
 
     def validate_file_path(self, value):
@@ -111,7 +110,6 @@ class UploadFileSerializer(serializers.Serializer):
 
 class QuickUploadFileSerializer(serializers.Serializer):
     """Serializer for quick file upload without edit session."""
-    user_id = serializers.IntegerField(required=True, min_value=1)
     file = serializers.FileField(required=True)
     target_path = serializers.CharField(required=False, allow_blank=True, max_length=512, default="files")
     description = serializers.CharField(required=False, allow_blank=True, max_length=200, default="")
@@ -140,7 +138,6 @@ class QuickUploadFileSerializer(serializers.Serializer):
 
 class DeleteFileSerializer(serializers.Serializer):
     """Serializer for file deletion."""
-    user_id = serializers.IntegerField(required=True, min_value=1)
     file_path = serializers.CharField(required=True, max_length=1024)
     commit_message = serializers.CharField(required=False, allow_blank=True, max_length=500)
 

--- a/editor/serializers.py
+++ b/editor/serializers.py
@@ -51,6 +51,21 @@ class PublishEditSerializer(serializers.Serializer):
     auto_push = serializers.BooleanField(default=True)
 
 
+class ResolveConflictSerializer(serializers.Serializer):
+    """Serializer for conflict resolution."""
+    session_id = serializers.IntegerField(required=True, min_value=1)
+    file_path = serializers.CharField(required=True, max_length=1024)
+    resolution_content = serializers.CharField(required=True)
+    conflict_type = serializers.CharField(required=False, default='text')
+
+    def validate_file_path(self, value):
+        """Validate file path is safe."""
+        # AIDEV-NOTE: path-validation; Prevent directory traversal attacks
+        if '..' in value or value.startswith('/'):
+            raise serializers.ValidationError("Invalid file path: no absolute paths or parent directory references allowed")
+        return value
+
+
 class ValidateMarkdownSerializer(serializers.Serializer):
     """Serializer for markdown validation."""
     content = serializers.CharField(required=True, allow_blank=True)

--- a/editor/templates/editor/edit.html
+++ b/editor/templates/editor/edit.html
@@ -236,7 +236,6 @@
         sessionId: null,
         branchName: null,
         filePath: '{{ file_path }}',
-        userId: {{ user.id|default:"1" }},
         lastSaved: null,
         modified: false,
         autoSaveTimer: null,
@@ -382,7 +381,6 @@
 
         try {
             const response = await axios.post(`${API_BASE}/start/`, {
-                user_id: editorState.userId,
                 file_path: editorState.filePath
             });
 
@@ -686,7 +684,6 @@
         const targetPath = lastSlashIndex > 0 ? filePath.substring(0, lastSlashIndex) : '';
 
         const formData = new FormData();
-        formData.append('user_id', editorState.userId);
         formData.append('file', file);
         formData.append('target_path', targetPath);
         formData.append('description', description || '');


### PR DESCRIPTION
### **User description**
## Summary

This PR enforces authentication for all critical API endpoints to prevent unauthorized file deletion, uploads, and edits. Fixes #60.

Includes additional security hardening based on code review feedback.

## Problem

Previously, any visitor could perform destructive operations without authentication:
- Delete files via `/editor/api/delete-file/`
- Upload files to main branch via `/editor/api/quick-upload-file/`
- Start edit sessions via `/editor/api/start/`
- Hardcoded `user_id: 1` in templates allowed operations as default user

**Security Risk**: HIGH - Any unauthenticated visitor could delete wiki pages, upload malicious files, or modify content.

## Solution

### Phase 1: Core Authentication Requirements
- Changed permission class from `IsAuthenticatedOrReadOnly` to `IsAuthenticated` on three endpoints
- Removed `user_id` fields from serializers (StartEditSerializer, QuickUploadFileSerializer, DeleteFileSerializer)
- Updated views to use `request.user` instead of request data
- Removed hardcoded `user_id: 1` from templates (display/attachment.html, editor/edit.html)

### Phase 2: Security Hardening
- **Fixed information disclosure**: Error messages no longer expose Git internals
- **Added email fallback**: Ensures valid email for git commits even when users don't have email set
- **Standardized user_info**: Consistent construction across all endpoints using `get_full_name()` or username
- **Enhanced audit logging**: All destructive operations log user ID and username for complete audit trail

### Phase 3: Comprehensive Testing
- Added `EditorAuthenticationTest` class with 6 tests
- Tests verify unauthenticated users are blocked (3 tests)
- Tests verify authenticated users can proceed (3 tests)
- All tests passing ✅

## Files Changed

**Core Authentication Changes:**
- `editor/api.py` - Updated 3 API views, added `IsAuthenticated` permission, improved error handling
- `editor/serializers.py` - Removed `user_id` from 3 serializers  
- `display/templates/display/attachment.html` - Removed hardcoded `user_id`
- `editor/templates/editor/edit.html` - Removed `userId` from state and API calls

**Tests:**
- `editor/tests.py` - Added 117+ lines of authentication tests

## Security Impact

**Before**: HIGH RISK
- ❌ Unauthenticated users could delete files
- ❌ Unauthenticated users could upload to main branch
- ❌ No proper user attribution in commits
- ❌ Hardcoded default user in templates
- ❌ Error messages exposed internal details

**After**: LOW RISK  
- ✅ Only authenticated users can delete files
- ✅ Only authenticated users can upload files
- ✅ Proper user attribution in git commits with email fallbacks
- ✅ API endpoints secured with `IsAuthenticated`
- ✅ No information disclosure in error responses
- ✅ Complete audit trail with user identification

## Testing

All authentication tests passing:
```
Ran 6 tests in 0.782s
OK
```

Test coverage:
- ✅ Unauthenticated delete file → 302/403
- ✅ Unauthenticated quick upload → 302/403
- ✅ Unauthenticated start edit → 302/403
- ✅ Authenticated delete file → Success with proper logging
- ✅ Authenticated quick upload → Not blocked by auth
- ✅ Authenticated start edit → Not blocked by auth

Audit logging verification:
```
INFO api User 1 (testuser) deleted file: test.md [EDITOR-DELETE01]
INFO api User 1 (testuser) quick uploaded file: test.txt [EDITOR-QUICK-UPLOAD01]
```

## Code Quality

- Follows existing project conventions (AIDEV-NOTE anchors, grepable log codes)
- Maintains atomic transaction support
- Backward compatible - no API contract changes
- Simplifies codebase by removing 20+ lines of manual user lookup logic

## Checklist

- [x] All destructive endpoints require authentication
- [x] Removed hardcoded user IDs from templates
- [x] All API views use `request.user`
- [x] Comprehensive tests added
- [x] All tests passing
- [x] Security vulnerability fixed
- [x] Information disclosure fixed
- [x] Audit logging enhanced
- [x] User attribution standardized

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Enforce authentication on all destructive API endpoints (delete, upload, start edit)

- Remove hardcoded user IDs from serializers and templates, use `request.user` instead

- Enhance security by removing information disclosure in error messages

- Standardize user attribution in git commits with email fallbacks

- Add comprehensive authentication tests (6 tests covering authenticated/unauthenticated access)

- Improve audit logging with user ID and username for all destructive operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["API Endpoints<br/>delete, upload, start"] -->|"Change permission<br/>to IsAuthenticated"| B["Authentication<br/>Required"]
  C["Serializers<br/>Remove user_id"] -->|"Use request.user<br/>instead"| D["Authenticated User<br/>from request"]
  E["Templates<br/>Remove hardcoded IDs"] -->|"No user_id<br/>in API calls"| F["Cleaner API<br/>Contracts"]
  B --> G["Security<br/>Hardened"]
  D --> G
  F --> G
  H["Error Messages<br/>Hide Git internals"] -->|"No details<br/>exposure"| G
  I["Audit Logging<br/>User ID + username"] -->|"Complete<br/>audit trail"| G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security, bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.py</strong><dd><code>Enforce authentication and standardize user handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

editor/api.py

<ul><li>Changed permission class from <code>IsAuthenticatedOrReadOnly</code> to <br><code>IsAuthenticated</code> on three endpoints (StartEditAPIView, <br>QuickUploadFileAPIView, DeleteFileAPIView)<br> <li> Removed manual user lookup logic and now use <code>request.user</code> directly for <br>all authenticated operations<br> <li> Standardized user_info construction using <code>user.get_full_name() or </code><br><code>user.username</code> with email fallback to <code>{username}@gitwiki.local</code><br> <li> Enhanced audit logging to include user ID and username in log messages <br>for all destructive operations<br> <li> Removed information disclosure by sanitizing error messages (e.g., <br>hiding Git internals in DeleteFileAPIView)</ul>


</details>


  </td>
  <td><a href="https://github.com/jmaddington/GitWiki/pull/64/files#diff-33cb35ea432c8ef4a30f8af4b2fc7b641759b23c64287f7a2fffa0eaac49a9be">+18/-38</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serializers.py</strong><dd><code>Remove user_id from all serializers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

editor/serializers.py

<ul><li>Removed <code>user_id</code> field from StartEditSerializer<br> <li> Removed <code>user_id</code> field from QuickUploadFileSerializer<br> <li> Removed <code>user_id</code> field from DeleteFileSerializer</ul>


</details>


  </td>
  <td><a href="https://github.com/jmaddington/GitWiki/pull/64/files#diff-ff6a898d08aae5f7e1c673acb6e40892cc80aa37ee9e98ab0c92d0a626c7ba50">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tests.py</strong><dd><code>Add authentication tests for destructive operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

editor/tests.py

<ul><li>Added new <code>EditorAuthenticationTest</code> class with 6 comprehensive tests<br> <li> Tests verify unauthenticated users receive 302/403 responses for <br>delete, upload, and start edit endpoints<br> <li> Tests verify authenticated users are not blocked by authentication <br>(status codes not 302/403)<br> <li> Includes setUp/tearDown with temporary repository and test user <br>creation</ul>


</details>


  </td>
  <td><a href="https://github.com/jmaddington/GitWiki/pull/64/files#diff-cb65becdf72b44d1e25e8842eb6a621df76fc431f512186f551de86e063a0fc5">+117/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Security</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>attachment.html</strong><dd><code>Remove hardcoded user ID from delete call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

display/templates/display/attachment.html

<ul><li>Removed hardcoded <code>user_id: 1</code> from the delete file API call in the <br>attachment preview</ul>


</details>


  </td>
  <td><a href="https://github.com/jmaddington/GitWiki/pull/64/files#diff-dba5a48218f380c83ab26becea6263da4773f69cdf412e21f51ee837f0ade36f">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>edit.html</strong><dd><code>Remove user ID from editor state and API calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

editor/templates/editor/edit.html

<ul><li>Removed <code>userId</code> field from editorState initialization (was set to <code>{{ </code><br><code>user.id|default:"1" }}</code>)<br> <li> Removed <code>user_id</code> parameter from the startEditSession API call<br> <li> Removed <code>user_id</code> parameter from the file upload FormData</ul>


</details>


  </td>
  <td><a href="https://github.com/jmaddington/GitWiki/pull/64/files#diff-3fc1023058a907c80fd9aed49298b0f1167cdf6bbd8d885b4fb98f54f02e1c5f">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

